### PR TITLE
Fix settings numeric parsing to allow decimal inputs

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -331,8 +331,19 @@ const Settings = () => {
   });
 
   const handleChange = (event: any) => {
-    const { name, value } = event.target;
-    const parsedValue = /^\d+$/.test(value) ? parseInt(value, 10) : value;
+    const { name, value, type } = event.target;
+
+    let parsedValue = value;
+
+    if (value === "") {
+      parsedValue = value;
+    } else if (typeof value === "number") {
+      parsedValue = value;
+    } else if (type === "number") {
+      const numericValue = Number(value);
+      parsedValue = Number.isNaN(numericValue) ? value : numericValue;
+    }
+
     setFormValues((prevValues) => ({
       ...prevValues,
       [name]: parsedValue,


### PR DESCRIPTION
## Summary
- update the settings form change handler to convert number inputs with decimal values into numbers
- retain support for sliders and empty inputs so settings persist correctly

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_b_68e83d40b6308320a694b48fc335b8cf